### PR TITLE
chore: update prism-php/prism version constraint in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "spatie/laravel-package-tools": "^1.18",
         "illuminate/support": "^11.0|^12.0",
         "illuminate/database": "^11.0|^12.0",
-        "prism-php/prism": "^0.56.0",
+        "prism-php/prism": ">=v0.56.0 < v1.0",
         "react/event-loop": "^1.5",
         "react/stream": "^1.4"
     },


### PR DESCRIPTION
Changed the version constraint for prism-php/prism from ^0.56.0 to >=v0.56.0 < v1.0 to allow for more flexible dependency management while preventing upgrades to v1.0 and above.

Alternatively, the version constraint could be updated often, but given the many releases of prism (we're already at `v0.79`) I think this is the easier way.